### PR TITLE
Fix: change the logic of equality checking for Widget IDs

### DIFF
--- a/gogtrends.go
+++ b/gogtrends.go
@@ -163,7 +163,7 @@ func Explore(ctx context.Context, r *ExploreRequest, hl string) ([]*ExploreWidge
 
 // InterestOverTime as list of `Timeline` dots for chart.
 func InterestOverTime(ctx context.Context, w *ExploreWidget, hl string) ([]*Timeline, error) {
-	if w.ID != intOverTimeWidgetID {
+	if !strings.HasPrefix(w.ID, intOverTimeWidgetID) {
 		return nil, ErrInvalidWidgetType
 	}
 
@@ -207,7 +207,7 @@ func InterestOverTime(ctx context.Context, w *ExploreWidget, hl string) ([]*Time
 
 // InterestByLocation as list of `GeoMap`, with geo codes and interest values.
 func InterestByLocation(ctx context.Context, w *ExploreWidget, hl string) ([]*GeoMap, error) {
-	if w.ID != intOverRegionID {
+	if !strings.HasPrefix(w.ID, intOverRegionID) {
 		return nil, ErrInvalidWidgetType
 	}
 
@@ -249,7 +249,7 @@ func InterestByLocation(ctx context.Context, w *ExploreWidget, hl string) ([]*Ge
 
 // Related topics or queries, list of `RankedKeyword`, supports two types of widgets.
 func Related(ctx context.Context, w *ExploreWidget, hl string) ([]*RankedKeyword, error) {
-	if w.ID != relatedQueriesID && w.ID != relatedTopicsID {
+	if !strings.HasPrefix(w.ID, relatedQueriesID) && !strings.HasPrefix(w.ID, relatedTopicsID) {
 		return nil, ErrInvalidWidgetType
 	}
 

--- a/gogtrends_test.go
+++ b/gogtrends_test.go
@@ -403,3 +403,46 @@ func TestCompareInterestConcurrent(t *testing.T) {
 		}()
 	}
 }
+
+func TestMultipleComparisonItems(t *testing.T) {
+	req := &ExploreRequest{
+		ComparisonItems: []*ComparisonItem{
+			{
+				Keyword: "Golang",
+				Geo:     locUS,
+				Time:    "today 12-m",
+			},
+			{
+				Keyword: "Python",
+				Geo:     locUS,
+				Time:    "today 12-m",
+			},
+		},
+		Category: catProgramming,
+		Property: "",
+	}
+
+	explore, err := Explore(context.Background(), req, langEN)
+	assert.NoError(t, err)
+
+	// Interest overtime for first keyword
+	overTime, err := InterestOverTime(context.Background(), explore[0], langEN)
+	assert.NoError(t, err)
+	assert.True(t, len(overTime) > 0)
+
+	// Interest by location for first keyword
+	byLoc, err := InterestByLocation(context.Background(), explore[1], langEN)
+	assert.NoError(t, err)
+	assert.True(t, len(byLoc) > 0)
+
+	// Interest overtime for second keyword
+	overTime, err = InterestOverTime(context.Background(), explore[3], langEN)
+	assert.NoError(t, err)
+	assert.True(t, len(overTime) > 0)
+
+	// Interest by location for second keyword
+	byLoc, err = InterestByLocation(context.Background(), explore[4], langEN)
+	assert.NoError(t, err)
+	assert.True(t, len(byLoc) > 0)
+
+}


### PR DESCRIPTION
Hey Max, thanks for this great package.

Today I encountered a bug (I assume it is). When using multiple ComparisonItem, checking the equality of widgets is failing. 

Reproducing the bug:

I created an `ExploreWidget` using `Explore` function.

```go
compare, err := gogtrends.Explore(ctx, &gogtrends.ExploreRequest{
	ComparisonItems: []*gogtrends.ComparisonItem{
		{
			Keyword: keywords[0],
			Geo:     location,
			Time:    date,
		},
		{
			Keyword: keywords[1],
			Geo:     location,
			Time:    date,
		},
	},
}, "EN")
```

Everything works fine here, this is the output of the `ExploreWidget`  when I iterate it.

```go
&{APP6_UEAAAAAX9OjpNJhEVoj3prChllfkoRP9ExHVy2s fe_line_chart Interest over time TIMESERIES 0xc0004ea240}
&{APP6_UEAAAAAX9OjpHPeKZIoXpXma9ciAnznpU3g4rsb fe_multi_heat_map Compared breakdown by subregion GEO_MAP 0xc0004ea5a0}
&{ fe_text  TITLE_0 <nil>}
&{APP6_UEAAAAAX9OjpIMIbe5xddzcCMLkyJo-QiZ9jb-_ fe_geo_chart_explore Interest by subregion GEO_MAP_0 0xc0004ea900}
&{APP6_UEAAAAAX9OjpG-7Vgq0uturH_LIpbhmmlxDMXuw fe_related_searches Related queries RELATED_QUERIES_0 0xc0004eab40}
&{ fe_text  TITLE_1 <nil>}
&{APP6_UEAAAAAX9OjpBteqtm7Twc9Wkqk3ubMmg-a1XdV fe_geo_chart_explore Interest by subregion GEO_MAP_1 0xc0004eaea0}
&{APP6_UEAAAAAX9OjpGaUS8hudzB_UQgOsHU_ghvg0Wug fe_related_searches Related queries RELATED_QUERIES_1 0xc0004eb0e0}
```

But as you can see. when we have multiple `ComparisonItem`. It created IDs by adding and incrementing an integer to the end.

But in here
https://github.com/groovili/gogtrends/blob/ecf6908d5ccf3c8ce7ea50410cbbd1fa05798c4b/vars.go#L23-L26

Everything is constant. So when I use `compare[4]` to get related results. It fails.

```go
relQ, err := gogtrends.Related(ctx, compare[4], "EN")
if err != nil {
	log.Fatal(err)
}
```

Because it does equality checking in here.

https://github.com/groovili/gogtrends/blob/ecf6908d5ccf3c8ce7ea50410cbbd1fa05798c4b/gogtrends.go#L251-L254

Checking the prefix should do good IMO. 






