### PR TITLE
Add fields to ComparisonItem struct

### DIFF
--- a/gogtrends_test.go
+++ b/gogtrends_test.go
@@ -604,7 +604,7 @@ func TestAutocomplete(t *testing.T) {
 	t.Error("failed to find topic")
 }
 
-func TestInterestOverTimeLast24Hours(t *testing.T) {
+func TestComparisonItemWithStartAndEndTime(t *testing.T) {
 	ctx := context.Background()
 	explore, err := Explore(ctx, &ExploreRequest{
 		ComparisonItems: []*ComparisonItem{

--- a/gogtrends_test.go
+++ b/gogtrends_test.go
@@ -603,3 +603,25 @@ func TestAutocomplete(t *testing.T) {
 
 	t.Error("failed to find topic")
 }
+
+func TestInterestOverTimeLast24Hours(t *testing.T) {
+	ctx := context.Background()
+	explore, err := Explore(ctx, &ExploreRequest{
+		ComparisonItems: []*ComparisonItem{
+			{
+				Keyword:                "Golang",
+				Time:                   "2021-09-05T09\\:16\\:00 2021-09-06T09\\:16\\:00",
+				GranularTimeResolution: true,
+				StartTime:              "2021-09-05T09:16:00.000Z",
+				EndTime:                "2021-09-06T09:16:00.000Z",
+			},
+		},
+		Category: catProgramming,
+		Property: "",
+	}, "EN")
+	assert.NoError(t, err)
+
+	overTime, err := InterestOverTime(ctx, explore[0], "EN")
+	assert.NoError(t, err)
+	assert.True(t, len(overTime) > 0)
+}

--- a/vars.go
+++ b/vars.go
@@ -138,9 +138,12 @@ type ExploreRequest struct {
 // ComparisonItem it's concrete search keyword
 // with Geo (can be found with ExploreLocations method) locality and Time period
 type ComparisonItem struct {
-	Keyword string `json:"keyword" bson:"keyword"`
-	Geo     string `json:"geo,omitempty" bson:"geo"`
-	Time    string `json:"time" bson:"time"`
+	Keyword                string `json:"keyword" bson:"keyword"`
+	Geo                    string `json:"geo,omitempty" bson:"geo"`
+	Time                   string `json:"time" bson:"time"`
+	GranularTimeResolution bool   `json:"granularTimeResolution" bson:"granularTimeResolution"`
+	StartTime              string `json:"startTime" bson:"startTime"`
+	EndTime                string `json:"endTime" bson:"endTime"`
 }
 
 // ExploreCatTree - available categories list tree

--- a/vars.go
+++ b/vars.go
@@ -141,9 +141,9 @@ type ComparisonItem struct {
 	Keyword                string `json:"keyword" bson:"keyword"`
 	Geo                    string `json:"geo,omitempty" bson:"geo"`
 	Time                   string `json:"time" bson:"time"`
-	GranularTimeResolution bool   `json:"granularTimeResolution" bson:"granularTimeResolution"`
-	StartTime              string `json:"startTime" bson:"startTime"`
-	EndTime                string `json:"endTime" bson:"endTime"`
+	GranularTimeResolution bool   `json:"granularTimeResolution" bson:"granular_time_resolution"`
+	StartTime              string `json:"startTime" bson:"start_time"`
+	EndTime                string `json:"endTime" bson:"end_time"`
 }
 
 // ExploreCatTree - available categories list tree


### PR DESCRIPTION
I added a few more fields to the ComparisonItem struct. I wanted to send an InterestOverTime request for the last 24 hours but it wasnt possible with the Time field.

Small example how to use the new fields:
```		
	ctx := context.Background()
	explore, _ := gogtrends.Explore(ctx, &gogtrends.ExploreRequest{
		ComparisonItems: []*gogtrends.ComparisonItem{
			{
				Keyword:                "bitcoin",
				Time:                   "2021-09-05T09\\:16\\:00 2021-09-06T09\\:16\\:00",
				GranularTimeResolution: true,
				StartTime:              "2021-09-05T09:16:00.000Z",
				EndTime:                "2021-09-06T09:16:00.000Z",
			},
		},
		Category: 7,
		Property: "",
	}, "EN")

	overTime, _ := gogtrends.InterestOverTime(ctx, explore[0], "EN")
```